### PR TITLE
asset-type & README

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,3 +87,20 @@ html hint tool, focused on semantic code style.
 	Custom rule file (.htmlcsrc) can be placed in the same/parent directory of target file, or the `~/` directory.
 
 	If found in neither paths, the default config will be used.
+
+* inline:
+
+	- disable
+
+		```html
+		<!-- htmlcs-disable -->
+		<!-- htmlcs-disable img-alt -->
+		<!-- htmlcs-disable img-alt, img-src, attr-value-double-quotes -->
+		```
+
+	- config
+
+		```html
+		<!-- htmlcs img-width-height: true -->
+		<!-- htmlcs img-width-height: true, indent-char: "tab" -->
+		```

--- a/lib/default/htmlcsrc
+++ b/lib/default/htmlcsrc
@@ -1,7 +1,7 @@
 {
     // Htmlcs Default Configuration File
 
-    "asset-type": true,                     // true: Default value of attribute "type" (<link>/<script>) should not be set
+    "asset-type": true,                     // true: Default value of attribute "type" (<link>/<style>/<script>) should not be set
     "attr-lowercase": true,                 // true: Attribute name must be lowercase
     "attr-no-duplication": true,            // true: Attribute name can not been duplication
     "attr-value-double-quotes": true,       // true: Attribute value must be closed by double quotes

--- a/lib/rules.js
+++ b/lib/rules.js
@@ -8,47 +8,6 @@ var util = require('./util');
 var rules = [];
 
 /**
- * Extract config info from comment content.
- *
- * @param {string} comment - comment content
- * @return {?Object} config info
- */
-var extractCommentInfo = function (comment) {
-    // htmlcs-disable img-alt, attr-value-double-quotes
-    var ablePattern = /^[\s\n]*htmlcs-(\w+)\s+([\w\-]+(?:,\s*[\w\-]+)*)?[\s\n]*$/;
-    // htmlcs "img-alt": false
-    var configPattern = /^[\s\n]*htmlcs\s([\s\S]*)$/;
-
-    var result;
-
-    if (ablePattern.test(comment)) {
-        result = ablePattern.exec(comment);
-
-        return {
-            operation: result[1],
-            content: result[2]
-        };
-    }
-
-    if (configPattern.test(comment)) {
-        result = configPattern.exec(comment)[1]
-            .replace(/([a-zA-Z0-9\-\/]+):/g, '"$1":')
-            .replace(/(\]|[0-9])\s+(?=")/, '$1,');
-
-        try {
-            result = JSON.parse('{' + result + '}');
-            return {
-                operation: 'config',
-                content: result
-            };
-        }
-        catch (e) {}
-    }
-
-    return null;
-};
-
-/**
  * class Rule
  *
  * @constructor
@@ -194,7 +153,7 @@ module.exports = {
     lintParser: function (parser, reporter, cfg, code) {
         // rule config in comment
         parser.on('comment', function (comment) {
-            var commentInfo = extractCommentInfo(comment);
+            var commentInfo = util.extractCommentInfo(comment);
 
             // if no valid info
             if (!commentInfo) {

--- a/lib/rules/asset-type.js
+++ b/lib/rules/asset-type.js
@@ -7,14 +7,14 @@ module.exports = {
 
     name: 'asset-type',
 
-    desc: 'Default value of attribute "type" (<link>/<script>) does not need to be set.',
+    desc: 'Default value of attribute "type" (<link>/<style>/<script>) does not need to be set.',
 
     lint: function (getCfg, document, reporter) {
         if (!getCfg()) {
             return;
         }
 
-        document.querySelectorAll('link[type="text/css"]').forEach(function (element) {
+        document.querySelectorAll('link[type="text/css"], style[type="text/css"]').forEach(function (element) {
             reporter.warn(
                 element.startIndex,
                 '001',
@@ -36,7 +36,9 @@ module.exports = {
             return;
         }
 
-        document.querySelectorAll('link[type="text/css"], script[type="text/javascript"]').forEach(function (element) {
+        document.querySelectorAll(
+            'link[type="text/css"], style[type="text/css"], script[type="text/javascript"]'
+        ).forEach(function (element) {
             element.removeAttribute('type');
         });
     }

--- a/lib/util.js
+++ b/lib/util.js
@@ -135,6 +135,47 @@ var getPosition = function (content, index) {
     return arguments.length > 1 ? position(index) : position;
 };
 
+/**
+ * Extract config info from comment content.
+ *
+ * @param {string} comment - comment content
+ * @return {?Object} config info
+ */
+var extractCommentInfo = function (comment) {
+    // htmlcs-disable img-alt, attr-value-double-quotes
+    var ablePattern = /^[\s\n]*htmlcs-(\w+)\s+([\w\-]+(?:,\s*[\w\-]+)*)?[\s\n]*$/;
+    // htmlcs "img-alt": false
+    var configPattern = /^[\s\n]*htmlcs\s([\s\S]*)$/;
+
+    var result;
+
+    if (ablePattern.test(comment)) {
+        result = ablePattern.exec(comment);
+
+        return {
+            operation: result[1],
+            content: result[2]
+        };
+    }
+
+    if (configPattern.test(comment)) {
+        result = configPattern.exec(comment)[1]
+            .replace(/([a-zA-Z0-9\-\/]+):/g, '"$1":')
+            .replace(/(\]|[0-9])\s+(?=")/, '$1,');
+
+        try {
+            result = JSON.parse('{' + result + '}');
+            return {
+                operation: 'config',
+                content: result
+            };
+        }
+        catch (e) {}
+    }
+
+    return null;
+};
+
 module.exports = {
     app: app,
     nodeType: ElementType,
@@ -143,5 +184,6 @@ module.exports = {
     extendAttribute: extendAttribute,
     cachable: cachable,
     getHomePath: getHomePath,
-    getPosition: getPosition
+    getPosition: getPosition,
+    extractCommentInfo: extractCommentInfo
 };

--- a/test/lib/rules/asset-type/case.html
+++ b/test/lib/rules/asset-type/case.html
@@ -9,6 +9,8 @@
 <body>
     <link href="">
     <link type="text/css" href="">
+    <style></style>
+    <style type="text/css"></style>
     <script src=""></script>
     <script type="text/plain" src=""></script>
     <script type="text/javascript" src=""></script>

--- a/test/lib/rules/asset-type/test.spec.js
+++ b/test/lib/rules/asset-type/test.spec.js
@@ -13,7 +13,7 @@ describe('hint rule ' + rule, function () {
     var result = htmlcs.hintFile(path.join(__dirname, 'case.html'));
 
     it('should return right result', function () {
-        expect(result.length).toBe(2);
+        expect(result.length).toBe(3);
 
         expect(result[0].type).toBe('WARN');
         expect(result[0].code).toBe('001');
@@ -21,9 +21,14 @@ describe('hint rule ' + rule, function () {
         expect(result[0].col).toBe(5);
 
         expect(result[1].type).toBe('WARN');
-        expect(result[1].code).toBe('002');
-        expect(result[1].line).toBe(14);
+        expect(result[1].code).toBe('001');
+        expect(result[1].line).toBe(13);
         expect(result[1].col).toBe(5);
+
+        expect(result[2].type).toBe('WARN');
+        expect(result[2].code).toBe('002');
+        expect(result[2].line).toBe(16);
+        expect(result[2].col).toBe(5);
     });
 });
 
@@ -33,11 +38,14 @@ describe('format rule ' + rule, function () {
     var document = parse(result);
 
     var links = document.querySelectorAll('link');
+    var styles = document.querySelectorAll('style');
     var scripts = document.querySelectorAll('script');
 
     it('should format well', function () {
         expect(links[0].hasAttribute('type')).toBe(false);
         expect(links[1].hasAttribute('type')).toBe(false);
+        expect(styles[0].hasAttribute('type')).toBe(false);
+        expect(styles[1].hasAttribute('type')).toBe(false);
         expect(scripts[0].hasAttribute('type')).toBe(false);
         expect(scripts[1].getAttribute('type')).toBe('text/plain');
         expect(scripts[2].hasAttribute('type')).toBe(false);


### PR DESCRIPTION
1. 规则`asset-type`添加对`<style>`标签的检查及format行为
2. 更新README，添加行内注释说明
3. `extractCommentInfo`方法挪到`util`中