### PR TITLE
debug add rule

### DIFF
--- a/lib/htmlcs.js
+++ b/lib/htmlcs.js
@@ -38,9 +38,6 @@ var hint = function (code, cfg) {
     var maxError = cfg['max-error'];
     delete cfg['max-error'];
 
-    // init rules
-    rules.init();
-
     // get reporter
     var reporter = new Reporter();
 
@@ -100,9 +97,6 @@ var format = function (code, cfg) {
         'max-char': 120,
         'formatter': otherFormatters
     }, cfg.format);
-
-    // init rules
-    rules.init();
 
     rules.format(document, cfg, inlineCfg.rules, options);
 

--- a/lib/rules.js
+++ b/lib/rules.js
@@ -23,7 +23,7 @@ var Rule = function (rule) {
  */
 Rule.prototype.target = 'document';
 
-module.exports = {
+var rulesManager = {
 
     /**
      * Init rules.
@@ -264,3 +264,7 @@ module.exports = {
         return this;
     }
 };
+
+rulesManager.init();
+
+module.exports = rulesManager;

--- a/test/lib/htmlcs.spec.js
+++ b/test/lib/htmlcs.spec.js
@@ -1,0 +1,65 @@
+/**
+ * @file test for lib/htmlcs
+ * @author nighca<nighca@live.cn>
+ */
+
+var htmlcs = require('../../lib/htmlcs');
+
+describe('htmlcs', function () {
+
+    describe('hint', function () {
+
+        it('should hint correctly', function () {
+            var code = '<html></html>';
+            var cfg = {
+                'html-lang': true
+            };
+
+            var result = htmlcs.hint(code, cfg);
+            expect(result.length).toBe(1);
+            expect(result[0].code).toBe('010');
+            expect(result[0].rule).toBe('html-lang');
+            expect(result[0].line).toBe(1);
+            expect(result[0].column).toBe(1);
+        });
+
+    });
+
+    describe('add rule', function () {
+
+        it('should add rule correctly', function () {
+            var code = '<html></html>';
+            var cfg = {
+                'html-lang': true
+            };
+            var rule = {
+                name: 'test-rule',
+                desc: 'Just a test rule.',
+                lint: function (getCfg, document, reporter) {
+                    reporter.warn(
+                        1,
+                        '099',
+                        'This is a test waring!'
+                    );
+                }
+            };
+
+            htmlcs.addRule(rule);
+            var result = htmlcs.hint(code, cfg);
+
+            expect(result.length).toBe(2);
+
+            expect(result[0].code).toBe('010');
+            expect(result[0].rule).toBe('html-lang');
+            expect(result[0].line).toBe(1);
+            expect(result[0].column).toBe(1);
+
+            expect(result[1].code).toBe('099');
+            expect(result[1].rule).toBe('test-rule');
+            expect(result[1].line).toBe(1);
+            expect(result[1].column).toBe(2);
+        });
+
+    });
+
+});


### PR DESCRIPTION
* 将 rules 的 init 行为放在 rules 模块被首次 require 时执行，避免每次调用 hint / format 时重复 rules.init 造成 addRule 失效
    https://github.com/ecomfe/htmlcs/issues/40
* 添加 lib/htmlcs.js 的测试用例