### PR TITLE
修复规则 attr-value-double-quotes 的 bug

### DIFF
--- a/lib/rules/attr-value-double-quotes.js
+++ b/lib/rules/attr-value-double-quotes.js
@@ -12,18 +12,19 @@ module.exports = {
     target: 'parser',
 
     lint: function (getCfg, parser, reporter) {
-        parser.on('attribute', function (name, value) {
-            if (!getCfg()) {
-                return;
-            }
+        parser.tokenizer.on('attribname', function (name) {
+            var buffer = this._buffer;
+            var index = this._index;
 
-            var tokenizer = this.tokenizer;
-            var start = tokenizer._index - value.length - 1;
-            var quote = tokenizer._buffer[start];
-
-            if (quote !== '"') {
+            // character after attribute name should be '='
+            // ( get rid of boolean attribute )
+            // and character starting attribute value should be '"'
+            if (
+                buffer[index] === '='
+                && buffer[index + 1] !== '"'
+            ) {
                 reporter.warn(
-                    quote === '\'' ? start : (start + 1),
+                    index + 1,
                     '028',
                     'Attribute value must be closed by double quotes.'
                 );

--- a/lib/rules/attr-value-double-quotes.js
+++ b/lib/rules/attr-value-double-quotes.js
@@ -13,6 +13,10 @@ module.exports = {
 
     lint: function (getCfg, parser, reporter) {
         parser.tokenizer.on('attribname', function (name) {
+            if (!getCfg()) {
+                return;
+            }
+
             var buffer = this._buffer;
             var index = this._index;
 

--- a/test/lib/rules/attr-value-double-quotes/case.html
+++ b/test/lib/rules/attr-value-double-quotes/case.html
@@ -11,6 +11,11 @@
     <img src='test'>
     <img src=test>
     <input type="text" value='' placeholder=xxx disabled self-defined-attr>
+    <img self-defined:attribute>
+    <img self-defined:attribute class="test">
+    <img self-defined:attribute=true>
+    <img self-defined:attribute="true">
+    <self:defined id="a" class='b' self-defined:attribute></self:defined>
     <!-- htmlcs-disable attr-value-double-quotes -->
     <img src='test'>
 </body>

--- a/test/lib/rules/attr-value-double-quotes/case.html
+++ b/test/lib/rules/attr-value-double-quotes/case.html
@@ -11,5 +11,7 @@
     <img src='test'>
     <img src=test>
     <input type="text" value='' placeholder=xxx disabled self-defined-attr>
+    <!-- htmlcs-disable attr-value-double-quotes -->
+    <img src='test'>
 </body>
 </html>

--- a/test/lib/rules/attr-value-double-quotes/case.html
+++ b/test/lib/rules/attr-value-double-quotes/case.html
@@ -10,5 +10,6 @@
     <img src="test">
     <img src='test'>
     <img src=test>
+    <input type="text" value='' placeholder=xxx disabled self-defined-attr>
 </body>
 </html>

--- a/test/lib/rules/attr-value-double-quotes/test.spec.js
+++ b/test/lib/rules/attr-value-double-quotes/test.spec.js
@@ -12,7 +12,7 @@ describe('hint rule ' + rule, function () {
     var result = htmlcs.hintFile(path.join(__dirname, 'case.html'));
 
     it('should return right result', function () {
-        expect(result.length).toBe(4);
+        expect(result.length).toBe(6);
 
         expect(result[0].type).toBe('WARN');
         expect(result[0].code).toBe('028');
@@ -33,5 +33,15 @@ describe('hint rule ' + rule, function () {
         expect(result[3].code).toBe('028');
         expect(result[3].line).toBe(13);
         expect(result[3].column).toBe(45);
+
+        expect(result[4].type).toBe('WARN');
+        expect(result[4].code).toBe('028');
+        expect(result[4].line).toBe(16);
+        expect(result[4].column).toBe(33);
+
+        expect(result[5].type).toBe('WARN');
+        expect(result[5].code).toBe('028');
+        expect(result[5].line).toBe(18);
+        expect(result[5].column).toBe(32);
     });
 });

--- a/test/lib/rules/attr-value-double-quotes/test.spec.js
+++ b/test/lib/rules/attr-value-double-quotes/test.spec.js
@@ -12,7 +12,7 @@ describe('hint rule ' + rule, function () {
     var result = htmlcs.hintFile(path.join(__dirname, 'case.html'));
 
     it('should return right result', function () {
-        expect(result.length).toBe(2);
+        expect(result.length).toBe(4);
 
         expect(result[0].type).toBe('WARN');
         expect(result[0].code).toBe('028');
@@ -23,5 +23,15 @@ describe('hint rule ' + rule, function () {
         expect(result[1].code).toBe('028');
         expect(result[1].line).toBe(12);
         expect(result[1].column).toBe(14);
+
+        expect(result[2].type).toBe('WARN');
+        expect(result[2].code).toBe('028');
+        expect(result[2].line).toBe(13);
+        expect(result[2].column).toBe(30);
+
+        expect(result[3].type).toBe('WARN');
+        expect(result[3].code).toBe('028');
+        expect(result[3].line).toBe(13);
+        expect(result[3].column).toBe(45);
     });
 });

--- a/test/lib/rules/button-name/case.html
+++ b/test/lib/rules/button-name/case.html
@@ -11,5 +11,7 @@
     <button name=""></button>
     <button name="submit"></button>
     <button type="submit"></button>
+    <!-- htmlcs button-name: false -->
+    <button name="submit"></button>
 </body>
 </html>


### PR DESCRIPTION
https://github.com/ecomfe/htmlcs/issues/55

采用更准确的事件及当前字符位置，通过检查 attribute name 后的字符是否`"="`，排除 boolean attribute