### PR TITLE
Add rule for DOCTYPE uppercase

### DIFF
--- a/lib/rules/doctype.js
+++ b/lib/rules/doctype.js
@@ -21,6 +21,9 @@ module.exports = {
             if (doctype.name !== 'html') {
                 reporter.warn(doctype.startIndex, '028', 'DOCTYPE must be html5.');
             }
+            if (doctype.data.split(" ")[0] !== '!DOCTYPE') {
+                reporter.warn(doctype.startIndex, '028', 'DOCTYPE should be uppercase.');
+            }            
         }
         else {
             reporter.warn(document.startIndex, '009', 'DOCTYPE needed.');


### PR DESCRIPTION
As discussed in #57 - a pull request representing a new rule that checks to make sure that the `<!DOCTYPE html>` is upper-case as in:

``` html5
<!DOCTYPE html>
```

As opposed to:

``` html5
<!doctype html>
```

Whilst the latter is technically OK as far as the HTML5 specification goes (Source: http://www.w3.org/TR/html5/syntax.html#the-doctype) and most modern browsers will be OK with it. It is generally considered good coding standards and a good convention to make `DOCTYPE` upper-case.

This is echoed in:
- https://google.github.io/styleguide/htmlcssguide.xml#Document_Type
- http://codeguide.co/ 

... and other credible sources.

More reading/discussions:
- http://stackoverflow.com/questions/7020961/uppercase-or-lowercase-doctype
- https://www.codecademy.com/forum_questions/515900165c8394fc690007de
- https://teamtreehouse.com/community/doctype-vs-doctype
- http://stackoverflow.com/questions/9265532/ie-and-html5-doctype-issues

_(N.B. I should note that my general experience with the `htmlcs` tool is limited so far - so, I'm not sure whether the `code` provided in the `reporter.warn()` function call of `028` should ideally be unique - if so, please feel free to reject this pull request and suggest an amendment/further tweak)_
