### PR TITLE
debug doctype-html5 rule code

### DIFF
--- a/lib/default/rule-map.json
+++ b/lib/default/rule-map.json
@@ -17,7 +17,7 @@
 
     "css-in-head": "008",
 
-    "doctype": "009",
+    "doctype": "009,041",
 
     "html-lang": "010",
 

--- a/lib/rules/doctype.js
+++ b/lib/rules/doctype.js
@@ -19,7 +19,7 @@ module.exports = {
         var doctype = document.doctype;
         if (doctype) {
             if (doctype.name !== 'html') {
-                reporter.warn(doctype.startIndex, '028', 'DOCTYPE must be html5.');
+                reporter.warn(doctype.startIndex, '041', 'DOCTYPE must be html5.');
             }
         }
         else {

--- a/test/lib/rules/doctype/test.spec.js
+++ b/test/lib/rules/doctype/test.spec.js
@@ -25,7 +25,7 @@ describe('rule ' + rule, function () {
         expect(result2.length).toBe(0);
 
         expect(result3[0].type).toBe('WARN');
-        expect(result3[0].code).toBe('028');
+        expect(result3[0].code).toBe('041');
         expect(result3[0].line).toBe(1);
         expect(result3[0].column).toBe(1);
     });


### PR DESCRIPTION
Use new code `041` for "DOCTYPE must be html5" in rule `doctype` because `028` is used in rule `attr-value-double-quotes`